### PR TITLE
Correzione del titolo del documento

### DIFF
--- a/document_settings.yml
+++ b/document_settings.yml
@@ -1,9 +1,9 @@
 document:
-  name: Linee Guida Open Source
+  name: Linee Guida su acquisizione e riuso di software per le pubbliche amministrazioni
   description:
-      Linee Guida Open Source
+      Linee guida in attuazione dagli articoli 68 e 69 del Codice dell’Amministrazione Digitale
   tags:
     - open source
     - linee guida
-    - gdl opensource
     - riuso
+    - software


### PR DESCRIPTION
Questa PR corregge il titolo visualizzato in Docs Italia:

https://docs.italia.it/AgID/linee-guida-riuso-software/lg-acquisizione-e-riuso-software-per-pa-docs/it/bozza/