### PR TITLE
Fix attachments index mapping new names

### DIFF
--- a/index-att.rst
+++ b/index-att.rst
@@ -1,8 +1,8 @@
 .. toctree::
    :caption: Indice degli allegati
 
-   attachments/allegato-b-guida-alla-pubblicazione-open-source-di-software-realizzato-per-la-pa.rst
-   attachments/allegato-c-guida-alla-manutenzione-di-software-open-source.rst
-   attachments/allegato-d-guida-alle-licenze-open-source.rst
-   attachments/allegato-e-guida-alla-modifica-di-software-open-source-preso-a-riuso-o-di-terzi.rst
-   attachments/allegato-f-tabella-sinottica-degli-elementi-necessari-al-percorso-decisionale.rst
+   attachments/allegato-a-guida-alla-pubblicazione-open-source-di-software-realizzato-per-la-pa.rst
+   attachments/allegato-b-guida-alla-manutenzione-di-software-open-source.rst
+   attachments/allegato-c-guida-alle-licenze-open-source.rst
+   attachments/allegato-d-guida-alla-modifica-di-software-open-source-preso-a-riuso-o-di-terzi.rst
+   attachments/allegato-e-tabella-sinottica-degli-elementi-necessari-al-percorso-decisionale.rst


### PR DESCRIPTION
This PR:
* ports the `index-att.rst` to the newer file names

@alranel 