### PR TITLE
Fix conf for new attachment names

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -23,10 +23,9 @@ latex_show_urls = False
 
 # Documents to append as an appendix to all manuals.
 latex_appendices = [
-    "attachments/allegato-b-guida-alla-pubblicazione-open-source-di-software-realizzato-per-la-pa",
-    "attachments/allegato-c-guida-alla-manutenzione-di-software-open-source",
-    "attachments/allegato-d-guida-alle-licenze-open-source",
-    "attachments/allegato-e-guida-alla-modifica-di-software-open-source-preso-a-riuso-o-di-terzi",
-    "attachments/allegato-e-guida-alla-modifica-di-software-open-source-preso-a-riuso-o-di-terzi",
-    "attachments/allegato-f-tabella-sinottica-degli-elementi-necessari-al-percorso-decisionale",
+    "attachments/allegato-a-guida-alla-pubblicazione-open-source-di-software-realizzato-per-la-pa",
+    "attachments/allegato-b-guida-alla-manutenzione-di-software-open-source",
+    "attachments/allegato-c-guida-alle-licenze-open-source",
+    "attachments/allegato-d-guida-alla-modifica-di-software-open-source-preso-a-riuso-o-di-terzi",
+    "attachments/allegato-e-tabella-sinottica-degli-elementi-necessari-al-percorso-decisionale",
 ]


### PR DESCRIPTION
This PR:
* removes a double entry from the `conf.py` file
* fixes the names of the attachments.

@sebbalex 